### PR TITLE
Calculate time_zone from lon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An [example file](examples/examples.ipynb) is provided along the package itself 
 In the framework of MELODIST a station object includes all relevant information including metadata and time series. A station is generated using the constructor method:
 
 ```python
-s = melodist.Station(lon=longitude, lat=latitude, timezone=timezone)
+s = melodist.Station(lon=longitude, lat=latitude, time_zone=timezone)
 ```
 
 Data is simply added by assignment (e.g., the data frame `data_obs_daily`):

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -82,7 +82,7 @@
     "path_inp = 'testdata.csv.gz'\n",
     "longitude = 8.86\n",
     "latitude = 51.00\n",
-    "timezone = 1\n",
+    "time_zone = 1\n",
     "\n",
     "calibration_period = slice('2014-01-01', '2015-12-31')\n",
     "validation_period = slice('2016-01-01', '2016-12-31')\n",
@@ -137,7 +137,7 @@
    "outputs": [],
    "source": [
     "station = melodist.Station(lon=longitude, lat=latitude,\n",
-    "                          timezone=timezone,\n",
+    "                          time_zone=timezone,\n",
     "                          data_daily=data_obs_daily)"
    ]
   },

--- a/melodist/radiation.py
+++ b/melodist/radiation.py
@@ -53,7 +53,7 @@ def disaggregate_radiation(data_daily,
         angstr_a: parameter a of the Angstrom model (intercept)
         angstr_b: parameter b of the Angstrom model (slope)
         mean_course: monthly values of the mean hourly radiation course
-        
+
     Returns:
         Disaggregated hourly values of shortwave radiation.
     """
@@ -93,7 +93,7 @@ def disaggregate_radiation(data_daily,
     return glob_disagg
 
 
-def potential_radiation(dates, lon, lat, timezone, terrain_slope=0, terrain_slope_azimuth=0,
+def potential_radiation(dates, lon, lat, time_zone=None, terrain_slope=0, terrain_slope_azimuth=0,
                         cloud_fraction=0, split=False):
     """
     Calculate potential shortwave radiation for a specific location and time.
@@ -114,7 +114,7 @@ def potential_radiation(dates, lon, lat, timezone, terrain_slope=0, terrain_slop
         Longitude (degrees)
     lat : float
         Latitude (degrees)
-    timezone : float
+    time_zone : float
         Time zone
     terrain_slope : float, default 0
         Terrain slope as defined in Liston & Elder (2006) (eq. 12)
@@ -140,7 +140,10 @@ def potential_radiation(dates, lon, lat, timezone, terrain_slope=0, terrain_slop
     solar_decline = tropic_of_cancer * np.cos(2.0 * np.pi * (day_of_year - solstice) / days_per_year)
 
     # compute the sun hour angle in rad
-    standard_meridian = timezone * 15.
+    if time_zone is None:
+        standard_meridian = round(lon/15.0) * 15.0
+    else:
+        standard_meridian = time_zone * 15.0
     delta_lat_time = (lon - standard_meridian) * 24. / 360.
     hour_angle = np.pi * (((dates_hour + dates_minute / 60. + delta_lat_time) / 12.) - 1.)
 

--- a/melodist/stationstatistics.py
+++ b/melodist/stationstatistics.py
@@ -38,11 +38,13 @@ class StationStatistics(object):
     generally associated to a Station object for which this infomration
     is valid.
     """
-    def __init__(self, data=None, lon=None, lat=None, timezone=None):
+    def __init__(self, data=None, lon=None, lat=None, time_zone=None):
         self._data = None
         self._lon = lon
         self._lat = lat
-        self._timezone = timezone
+        self._time_zone = time_zone
+        if time_zone is None and lon is not None:
+            self._time_zone = round(lon/15.0)
 
         if data is not None:
             self.data = data
@@ -83,7 +85,7 @@ class StationStatistics(object):
         months :        Months for each seasons to be used for statistics (array of numpy array, default=1-12, e.g., [np.arange(12) + 1])
         avg_stats :     average statistics for all levels True/False (default=True)
         percentile :    percentil for splitting the dataset in small and high intensities (default=50)
-        
+
         """
         if months is None:
             months = [np.arange(12) + 1]
@@ -112,7 +114,7 @@ class StationStatistics(object):
         """
         Calculates statistics in order to derive diurnal patterns of temperature
         """
-        self.temp.max_delta = melodist.get_shift_by_data(self.data.temp, self._lon, self._lat, self._timezone)
+        self.temp.max_delta = melodist.get_shift_by_data(self.data.temp, self._lon, self._lat, self._time_zone)
         self.temp.mean_course = melodist.util.calculate_mean_daily_course_by_month(self.data.temp, normalize=True)
 
     def calc_radiation_stats(self, data_daily=None, day_length=None, how='all'):
@@ -135,7 +137,7 @@ class StationStatistics(object):
         if data_daily is not None:
             pot_rad = melodist.potential_radiation(
                 melodist.util.hourly_index(data_daily.index),
-                self._lon, self._lat, self._timezone)
+                self._lon, self._lat, self._time_zone)
             pot_rad_daily = pot_rad.resample('D').mean()
             obs_rad_daily = self.data.glob.resample('D').mean()
 

--- a/melodist/temperature.py
+++ b/melodist/temperature.py
@@ -212,16 +212,18 @@ def disaggregate_temperature(data_daily,
     return temp_disagg
 
 
-def get_shift_by_data(temp_hourly, lon, lat, time_zone):
+def get_shift_by_data(temp_hourly, lon, lat, time_zone=None):
     '''function to get max temp shift (monthly) by hourly data
-    
+
     Parameters
     ----
-    hourly_data_obs : observed hourly data 
+    hourly_data_obs : observed hourly data
     lat :             latitude in DezDeg
     lon :             longitude in DezDeg
-    time_zone:        timezone
+    time_zone:        time zone, if None calculated from `lon`
     '''
+    if time_zone is None:
+        time_zone = round(lon/15.0)
     daily_index = temp_hourly.resample('D').mean().index
     sun_times = melodist.util.get_sun_times(daily_index, lon, lat, time_zone)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -20,7 +20,7 @@ def setup_station():
 
     df_daily = melodist.util.daily_from_hourly(df_hourly)
 
-    station = melodist.Station(lon=8.86, lat=51.00, timezone=1, data_daily=df_daily)
+    station = melodist.Station(lon=8.86, lat=51.00, time_zone=1, data_daily=df_daily)
     station.statistics = melodist.StationStatistics(data=df_hourly)
 
     return station


### PR DESCRIPTION
Calculate time_zone from lon with "round(lon/15.0)".
Normalize "timezone" to "time_zone".
Where "time_zone" is positional argument, make keyword = None

Suggest even dropping "time_zone" altogether since I can't see a reason why you would want a "time_zone" different from what is calculated from "lon".  However, dropping "time_zone" would mean changing function signature, whereas converting to a keyword is backwards compatible.